### PR TITLE
Add a delete() method to RCFile

### DIFF
--- a/discuss/rcfile.py
+++ b/discuss/rcfile.py
@@ -155,3 +155,10 @@ class RCFile:
         self.entries[mtg_id] = entry
         self.recache()
 
+    def delete(self, meeting):
+        """Remove a meeting from the .meetings file"""
+        mtg = self.lookup(meeting)
+        if mtg not in self.entries:
+            raise ValueError("'%s' is not in meetings file." % meeting)
+        del self.entries[mtg]
+        self.recache()


### PR DESCRIPTION
Support deletion of meetings, and raise a ValueError if there is
an attempt to delete a non-existent meeting.  Like add(), the
delete() method does not call save() -- that is up to the caller
