### PR TITLE
Enhancements to python-discuss from the pergamon project

### DIFF
--- a/discuss/client.py
+++ b/discuss/client.py
@@ -309,6 +309,10 @@ class Meeting(object):
         if result != 0:
             raise DiscussError(result)
 
+    def ensure_access(self, principal, modes):
+        current = self.get_access(principal)
+        self.set_access(principal, current+modes)
+
     @autoreconnects
     def undelete_transaction(self, trn_number):
         """Undelete the transaction by its number."""

--- a/discuss/client.py
+++ b/discuss/client.py
@@ -72,7 +72,9 @@ class Client(object):
         request.put_string(long_mtg_name)
         request.put_boolean(public)
         reply = self.rpc.request(request)
-        return reply.read_long_integer()
+        result = reply.read_long_integer()
+        if result != 0:
+            raise DiscussError(result)
 
     def close(self):
         """Disconnect from the server."""

--- a/discuss/client.py
+++ b/discuss/client.py
@@ -43,7 +43,7 @@ def autoreconnects(f):
 class Client(object):
     """Discuss client."""
 
-    def __init__(self, server, port = 2100, auth = True, timeout = None):
+    def __init__(self, server, port = 2100, auth = True, timeout = None, RPCClient=RPCClient):
         self.rpc = RPCClient(server, port, auth, timeout)
         if auth and self.who_am_i().startswith("???@"):
             raise ProtocolError("Authentication to server failed")

--- a/discuss/client.py
+++ b/discuss/client.py
@@ -65,6 +65,15 @@ class Client(object):
         reply = self.rpc.request(request)
         return reply.read_string()
 
+    @autoreconnects
+    def create_mtg(self, location, long_mtg_name, public):
+        request = USPBlock(constants.CREATE_MTG)
+        request.put_string(location)
+        request.put_string(long_mtg_name)
+        request.put_boolean(public)
+        reply = self.rpc.request(request)
+        return reply.read_long_integer()
+
     def close(self):
         """Disconnect from the server."""
 

--- a/discuss/client.py
+++ b/discuss/client.py
@@ -315,6 +315,11 @@ class Meeting(object):
         current = self.get_access(principal)
         self.set_access(principal, current+modes)
 
+    def remove_access(self, principal, modes):
+        current = self.get_access(principal)
+        new_modes = ''.join(c for c in current if not c in modes)
+        self.set_access(principal, new_modes)
+
     @autoreconnects
     def undelete_transaction(self, trn_number):
         """Undelete the transaction by its number."""


### PR DESCRIPTION
The normal discuss clients will run disserve when connecting to a local discuss
server, which is potentially handy for utilities running on the discuss server
that don't have convenient access to a keytab. This adds support for that mode
of operation to pydiscuss as well.

(I suspect this wants some changes before being merged, but it'd be nice to know what sorts of changes you want, rather than trying to guess.)
